### PR TITLE
Attempt at fixing typeform mobile loading issue

### DIFF
--- a/src/components/typeform.js
+++ b/src/components/typeform.js
@@ -1,57 +1,70 @@
-import React, { useEffect, useState, useRef } from 'react';
-import Head from '@docusaurus/Head';
+import React, { useEffect, useState, useRef } from "react";
+import Head from "@docusaurus/Head";
 
 export function TypeformWidget(props) {
   const [widgetLoaded, setWidgetLoaded] = useState(false);
   const widgetStyle = {
-    width: '100%',
-    height: '500px',
-    transition: 'opacity 0.3s ease-in',
-    opacity: widgetLoaded ? '1' : '0',
+    width: "100%",
+    height: "500px",
+    transition: "opacity 0.3s ease-in",
+    opacity: widgetLoaded ? "1" : "0",
   };
 
   const typeformStyle = {
-    fontFamily: 'Sans-Serif',
-    fontSize: '12px',
-    color: '#999',
-    opacity: '0.5',
-    paddingTop: '5px',
+    fontFamily: "Sans-Serif",
+    fontSize: "12px",
+    color: "#999",
+    opacity: "0.5",
+    paddingTop: "5px",
   };
   const { campaign } = props;
 
+  function makeWidget(c) {
+    if (typeof document !== "undefined") {
+      const el = document.getElementById("mg-embedded-typeform");
+      const doWidget = setTimeout(() => {
+        window.typeformEmbed.makeWidget(
+          el,
+          "https://form.typeform.com/to/" + c,
+          {
+            hideFooter: true,
+            hideHeaders: true,
+            opacity: 0,
+          }
+        );
+        setWidgetLoaded(true);
+      }, 500);
+
+      return doWidget;
+    }
+  }
   useEffect(() => {
     // Typeforms widget JS
-    const el = document.getElementById('mg-embedded-typeform');
-    const doWidget = setTimeout(() => {
-      window.typeformEmbed.makeWidget(
-        el,
-        'https://form.typeform.com/to/' + campaign,
-        {
-          hideFooter: true,
-          hideHeaders: true,
-          opacity: 0,
-        },
-      );
-      setWidgetLoaded(true);
-    }, 300);
-
-    doWidget;
+    if (document.readyState !== "loading") {
+      makeWidget(campaign);
+    } else {
+      document.addEventListener("DOMContentLoaded", function () {
+        console.log(campaign);
+        makeWidget(campaign);
+      });
+    }
 
     return () => {
-      clearTimeout(doWidget);
+      window.removeEventListener("DOMContentLoaded", makeWidget);
+      setWidgetLoaded(!widgetLoaded);
     };
-  }, []);
+  }, [campaign]);
 
   return (
     <>
       <Head>
         <script
-          src='https://embed.typeform.com/embed.js'
+          src="https://embed.typeform.com/embed.js"
           async
-          id='typef_orm'
+          id="typef_orm"
         ></script>
       </Head>
-      <div id='mg-embedded-typeform' style={widgetStyle}></div>
+      <div id="mg-embedded-typeform" style={widgetStyle}></div>
     </>
   );
 }


### PR DESCRIPTION
I have tested this fix on my mobile via Ngrok tunnel to my dev machine and it seemed to be OK.

The issue can be replicated by visiting [Join MetaGame on the live wiki](https://wiki.metagame.wtf/docs/enter-metagame/join-metagame) and [Join MetaGame on the deploy preview](https://metagame-wiki-5wgwrz4ty.vercel.app/docs/enter-metagame/join-metagame) on a mobile device - iPad or iPhone ideally as this is a device I do not have access to. On live, the form does not load for mobile devices. On preview, the form should now load.

I have tested on two Android devices and the form is now displaying on the deploy preview for those devices.  

Apologies for the additional noise from Prettier.