### PR TITLE
Create wiki page for calendar

### DIFF
--- a/docs/resources/calendar.mdx
+++ b/docs/resources/calendar.mdx
@@ -1,0 +1,24 @@
+---
+title: 📆 Calendar
+---
+
+import useBaseUrl from '@docusaurus/useBaseUrl';
+
+# Events Calendar
+
+## Upcoming events
+
+**Times are in UTC, not necessarily your local timezone!**
+
+<iframe src="https://calendar.google.com/calendar/embed?height=600&amp;wkst=1&amp;bgcolor=%23ffffff&amp;ctz=UTC&amp;src=bmloNTlrdGdhZm1tNjRlZDRxazZ1ZTh2djRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;src=MXFuYnI5Nzk2bm5lbm41M2NpYmh2ZWtoNThAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&amp;color=%23F09300&amp;color=%23D50000&amp;mode=AGENDA" width="800" height="600" scrolling="no"></iframe>
+
+
+## Staying up to date
+
+A number of tools and application support synchronization with Google Calendar.
+For example, any calendar application on your iOS or Android phone.
+
+Furthermore it is possible for anyone interested to customize the way you are notified about event changes, updates, and new events.
+
+Instructions to configure various applications and operating systems are out of scope.
+But we are happy to help if you can't figure it out, just ask us on Discord!

--- a/sidebars.js
+++ b/sidebars.js
@@ -58,6 +58,7 @@ module.exports = {
       // 'resources/alignment2021',
     ],
     "🌳 Other": [
+      "resources/calendar",
       "resources/glossary",
       "resources/graphics",
       "resources/art",

--- a/src/components/signpost.js
+++ b/src/components/signpost.js
@@ -58,8 +58,8 @@ export const directions = [
     emoji: "📅",
     label: "Calendar",
     url:
-      "https://calendar.google.com/calendar/u/1?cid=bmloNTlrdGdhZm1tNjRlZDRxazZ1ZTh2djRAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ",
-    description: "Townhall Gatherings & Meetups.",
+      "https://calendar.google.com/calendar/embed?src=nih59ktgafmm64ed4qk6ue8vv4%40group.calendar.google.com&ctz=",
+    description: "Meetings, gatherings and events",
   },
   {
     emoji: "🧙",

--- a/src/components/signpost.js
+++ b/src/components/signpost.js
@@ -58,7 +58,7 @@ export const directions = [
     emoji: "📅",
     label: "Calendar",
     url:
-      "https://calendar.google.com/calendar/embed?src=nih59ktgafmm64ed4qk6ue8vv4%40group.calendar.google.com&ctz=",
+      "docs/resources/calendar",
     description: "Meetings, gatherings and events",
   },
   {


### PR DESCRIPTION
The 'calendar' link in the app drawer was pointing to a calendar URL that requires a Google login to visit.
The first commit points to a publicly accessible calendar view.

The second commit creates a 'calendar' page that contains:
 * an embedded preview of the calendar
 * placeholder/instructions for people to subscribe to the calendar

I expect over time this will reduce attrition with people not being able to discover/read/subscribe to the calendar