### PR TITLE
Updated "Join as a Patron" to instruct single asset despoisting of WETH

### DIFF
--- a/docs/enter-metagame/join-metagame.md
+++ b/docs/enter-metagame/join-metagame.md
@@ -16,8 +16,7 @@ import { TypeformWidget } from '../../src/components/typeform';
 ## Join as a Patron
 Eager to support the cause & impatient to join?
 You can skip the queue by joining as a Patron instead!
-- Pick up a minimum of 6 Seeds [here](https://balancer.exchange/#/swap/ether/0x30cf203b48edaa42c3b4918e955fed26cd012a3f)
-- Plant them in [here](https://pools.balancer.exchange/#/pool/0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e/)
+- Water our seeds by depositing WETH [here](https://pools.balancer.exchange/#/pool/0xea05a15dbce2eb543ffda16950e95b2bd2e40d0e/)(Make sure you deposit enough WETH to generate 8 pSEEDs.)
 - Enter [here](https://discord.gg/d3rurFAK6M) & type in "!join"
 
 Want a more in-depth guide to doing this? Check the [Patrons Path](https://www.notion.so/Patron-Path-1db90c8bb4c84398a6fe1f672ea5e855).


### PR DESCRIPTION
Updated "Join as a Patron" to instruct single asset depositing of WETH into the Balancer pool for pSEEDs, instead of purchasing and planting Seeds.

This solves issue #242.