### PR TITLE
updated config to allow for "Last updated..." info on docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,11 +23,8 @@ module.exports = {
         src: "img/mg-crystal.png",
       },
     },
-
-    },
-    scripts: [
-        "./static/scripts/confetti.js"
-  ],
+  },
+  scripts: ["./static/scripts/confetti.js"],
   presets: [
     [
       "@docusaurus/preset-classic",
@@ -35,6 +32,8 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl: "https://wiki.metagame.wtf/admin/#/?",
+          showLastUpdateTime: true,
+          showLastUpdateAuthor: true,
         },
         theme: {
           customCss: require.resolve("./src/css/custom.scss"),


### PR DESCRIPTION
Adding "Last updated..." to each doc page as requested in #256 

The local build uses mock data so I think we'll want to check this out on a preview deploy.

Update: The preview deploy looks like it's using the correct data.