### PR TITLE
Added Playbooks to CMS GUI

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -21,10 +21,22 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
   - name: "great-houses"
     label: "Great Houses"
     folder: "docs/great-houses"
@@ -34,10 +46,22 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
   - name: "Guilding"
     label: "Guilding"
     folder: "docs/Guilding"
@@ -47,10 +71,22 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
   - name: "how-does-it-work"
     label: "How Does It Work"
     folder: "docs/how-does-it-work"
@@ -60,10 +96,22 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
   - name: "resources"
     label: "Resources"
     folder: "docs/resources"
@@ -73,10 +121,22 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
   - name: "start-here"
     label: "Start Here"
     folder: "docs/start-here"
@@ -86,10 +146,22 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
   - name: "wtf-is-metagame"
     label: "WTF is MetaGame"
     folder: "docs/wtf-is-metagame"
@@ -99,7 +171,44 @@ collections:
     editor:
       preview: false
     fields:
-      - {label: "Title", name: "title", widget: "string"}
-      - {label: "Description", name: "description", widget: "string", required: false, hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents."}
-      - {label: "Cover Image",name: "image", widget: "image", required: false,  hint: "Cover or thumbnail image that will be used when displaying the link to the post."}
-      - {label: "Body", name: "body", widget: "markdown"}
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }
+  - name: "playbooks"
+    label: "Playbooks"
+    folder: "docs/playbooks"
+    create: true
+    slug: "{{slug}}"
+    preview_path: "docs/playbooks/{{slug}}"
+    editor:
+      preview: false
+    fields:
+      - { label: "Title", name: "title", widget: "string" }
+      - {
+          label: "Description",
+          name: "description",
+          widget: "string",
+          required: false,
+          hint: "The description of the post which will be used by search engines and link previews. If not present, will default to the first line of the post contents.",
+        }
+      - {
+          label: "Cover Image",
+          name: "image",
+          widget: "image",
+          required: false,
+          hint: "Cover or thumbnail image that will be used when displaying the link to the post.",
+        }
+      - { label: "Body", name: "body", widget: "markdown" }


### PR DESCRIPTION
This PR resolves #253 -- Since NetlifyCMS is a bit tricky to test locally, I cloned our repo and made a version on a personal Vercel deploy for testing:

![playbooks-cms-ui](https://user-images.githubusercontent.com/9438776/125301608-23c85e00-e2f9-11eb-9755-318ccd97f99a.jpg)

Here's the link to my cloned deploy: https://metagame-wiki-jp.vercel.app/admin#/

If you log in with your creds you'll be able to test it out. I didn't actually create a Playbook with this since I wasn't sure how that would impact our existing content, but wanted to at least get these added to the collections UI.