### PR TITLE
Make use of will-change: transform to boost scrolling performance

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -47,19 +47,28 @@ body {
 
 body,
 .main-wrapper {
-    background-color: var(--ifm-color-primary-dark);
     color: var(--mf-color-text-body);
     font-family: var(--mf-font-body), sans-serif;
 
     &:not(body) {
-        background-image: url('/img/mymeta-bg.jpg');
-        background-size: cover;
-        background-attachment: fixed;
-        width: 100%;
-        min-height: 100vh;
         padding: 0;
         margin-top: -40px;
         padding-top: 40px;
+        position: relative; // added for pseudo-element
+
+        // Fixed-position background image
+        &::before {
+            content: ' ';
+            position: fixed; // instead of background-attachment
+            width: 100%;
+            height: 100%;
+            top: 0;
+            right: 0;
+            background: url('/img/mymeta-bg.jpg') no-repeat center center;
+            background-size: cover;
+            will-change: transform; // creates a new paint layer
+            z-index: -1;
+        }
 
         @media screen and (min-width: 768px) {
             margin-top: -60px;


### PR DESCRIPTION
This PR boosts the scrolling performance of metagame-wiki by applying the `will-change: transform` on the pseudo element displaying the background image, which gets rid of constant re-rendering of the background image each time the user scrolls (Check the #296 for more info).

This PR includes a slight change in how the background image is and will be positioned by resizing or viewing the site in different browser window sizes, but unless anyone strongly objects against this change, I would consider the noticable performance boost a worth gain for the price of it.

If anyone explicitly wants it, I can also take a closer look into how to keep the current behaviour of the background image - actually I already have an idea how to implement it, but I think it would add unnecessary complexity into the code.

You can check the before/after here: https://easyupload.io/six68p It might not be the best representation of the change, because of the gif's framerate, but you can trust me it feels much better. I can record another video with higher framerate if needed but I recommend you try it on your own with a touchpad or on the phone.

Closes #296