### PR TITLE
GA tags to make GA track traffic properly.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,13 +6,17 @@ module.exports = {
   favicon: "img/mg-icon.png",
   organizationName: "MetaFam",
   projectName: "metagame-wiki",
-  customFields: {
-    GA_TAG: process.env.GA_TAG,
-  },
+  // customFields: {
+  //   GA_TAG: process.env.GA_TAG,
+  // },
   themeConfig: {
     colorMode: {
       defaultMode: "dark",
       disableSwitch: true,
+    },
+    gtag: {
+      trackingID: 'UA-183634343-1',
+      anonymizeIP: true, // We don't need to know folks IPs
     },
     image: "img/wiki-cover.png",
     // headerLinks: [{ page: 'help', label: 'Help' }],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,7 @@ module.exports = {
       disableSwitch: true,
     },
     gtag: {
-      trackingID: 'UA-183634343-1',
+      trackingID: 'G-9SQ6R9576M',
       anonymizeIP: true, // We don't need to know folks IPs
     },
     image: "img/wiki-cover.png",


### PR DESCRIPTION
Saimano added the GA tag in customFields which was only set up to track the root of the wiki '/' which was the way to do it in V1 but we weren't getting any data for other page views, so I have added in the `gtag` for the theme which is the recommended method given in the Docusaurus V2 docs.

Tested on a local prod server it is working as expected. 