### PR TITLE
Fixes #244 - 404 on /docs.

### DIFF
--- a/docs/home.mdx
+++ b/docs/home.mdx
@@ -1,6 +1,7 @@
 ---
 title: 💠 App Drawer
 hide_title: true
+slug: /
 ---
 
 import { Signpost, directions } from '../src/components/signpost';

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,5 +48,16 @@ module.exports = {
     require.resolve("docusaurus-lunr-search"),
     require.resolve("docusaurus-plugin-sass"),
     "docusaurus2-dotenv",
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            to: '/docs/', // string
+            from: ['/docs/home/'], // string | string[]
+          },
+        ],
+      },
+    ],
   ],
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.7",
+    "@docusaurus/plugin-client-redirects": "^2.0.0-beta.7",
     "@docusaurus/preset-classic": "^2.0.0-beta.7",
     "@vercel/node": "^1.9.0",
     "classnames": "^2.2.6",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -334,7 +334,7 @@ function Home() {
                     'button button--primary button--lg button--explore',
                     styles.button
                   )}
-                  to={useBaseUrl('docs/home')}
+                  to={useBaseUrl('docs/')}
                 >
                   EXPLORE
                 </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,6 +1374,23 @@
     url-loader "^4.1.1"
     webpack "^5.40.0"
 
+"@docusaurus/plugin-client-redirects@^2.0.0-beta.7":
+  version "2.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.0.0-beta.7.tgz#cbe1831ed9e21a001f92241ed1202b463c328dab"
+  integrity sha512-F98HKcLaR33Q2gcF116WAz5Pz5GMXiDQaWTlzeTDCvtLsOpdu1NZDMo9kMwUg7q9rTDaS5Wy1igEdI5ayk9FSA==
+  dependencies:
+    "@docusaurus/core" "2.0.0-beta.7"
+    "@docusaurus/types" "2.0.0-beta.7"
+    "@docusaurus/utils" "2.0.0-beta.7"
+    "@docusaurus/utils-common" "2.0.0-beta.7"
+    "@docusaurus/utils-validation" "2.0.0-beta.7"
+    chalk "^4.1.2"
+    eta "^1.12.3"
+    fs-extra "^10.0.0"
+    globby "^11.0.2"
+    lodash "^4.17.20"
+    tslib "^2.3.1"
+
 "@docusaurus/plugin-content-blog@2.0.0-beta.7":
   version "2.0.0-beta.7"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.7.tgz#f40d9314f2ea07e0cea75e0eeaae79a259f8c937"


### PR DESCRIPTION
- Added the `slug` field in the frontmatter in `home.mdx` which sets it as the root page for the docs.
- Installed the redrects plugin for docusaurus as mentioned by @tommymaher15 which is set to redirect `/docs/home` to `/docs`