### PR TITLE
add-xp-playbook

### DIFF
--- a/docs/playbooks/mgxp-metagame-experience-points.md
+++ b/docs/playbooks/mgxp-metagame-experience-points.md
@@ -1,0 +1,59 @@
+---
+title: 📚 MGXP Metagame Experience Points
+description: 'This Playbook focuses on how XP works in MetaGame and how to earn it.'
+image: https://i.imgur.com/W3MNipm.jpg
+---
+
+by @Maxwe11
+
+<details>
+<summary>🤔 Wait, WhoTF is @Maxwe11!?</summary>
+<br />
+ Maxwe11 is a patron and a curiousity driven resident of MetaGame. He can be found in Discord as Maxwe11#7157.
+</details>
+<br />
+
+## What are MetaGame Experience Points (MGXP)?
+XP is the way we track Player progress in MetaGame. As you play the game, you earn XP, which progresses you up the leaderboard and also determines how many [seeds](https://metagame.wtf/seeds) you can earn.
+
+## How can I earn XP?
+
+MetaGame uses [Sourcecred](https://sourcecred.io/) to calculate a player’s contributions to the game, and translates those actions in to XP. The following tools are inputs in to the XP system:
+
+1. Github - Contributions to [MetaGame’s repository](https://github.com/MetaFam)
+2. Discourse - Long form discussion, proposals, governance, etc. in the [MetaGame forum](https://forum.metagame.wtf/)
+3. [Discord](https://discord.gg/f59d4Tf) - Home to the social collaboration of MetaGame. Community calls, announcements, workgroups, idea exchange.
+
+## So I just spam a lot in Discord and I get XP?
+
+So. Many. One. Word. Posts. 
+
+Actually, Players determine how much your contributions in Discord are worth. XP in Discord is weighted according to the community’s reactions to it. When you participate in the community, Players can reward that contribution by reacting to your posts. Those reactions are what determines how much XP is awarded.
+
+## What if I did something, but it’s not in Discord?
+
+[#did-a-thing](https://discord.com/channels/629411177947987986/692892074198040647) - This channel in the MetaGame Discord server is designed for players to tell the community about things they have done for MetaGame. In this channel, there is a specific template you should use, and a reaction scale will appear beneath your post. Shill yourself here.
+
+>**Branch**: The role or category of your contribution. <br />
+>**Description**: A description of your actual contribution <br />
+>**Effort**: How much effort did you put in to this? low/med/high or approximate time spent <br />
+>**Impact**: How much did it benefit MetaGame? low/med/high or specific explanation of impact <br />
+>**Artifact**: Is there a link or screenshot of your contribution? <br />
+
+## What if I want to bring attention to something another Player did?
+
+[#give-props](https://discord.com/channels/629411177947987986/718557002221224037) - This channel is for anyone to call out another Player for things they have done in MetaGame. Player’s reactions to these posts will be assigned to the people tagged in the post, not the creator of the post. Shill others here.
+
+## Where do quests fit in?
+
+So you completed a quest and it was approved. What now? Currently completed quests are posted in [#give-props](https://discord.com/channels/629411177947987986/718557002221224037). See available quests [here](https://metagame.wtf/quests), or Quest Chains (like Quests, but with multiple steps) [here](https://metagame.wtf/roles). Once you complete it, our friendly bot will post your completion.
+
+## So all emoji reactions are treated the same?
+
+Nope! Reactions are weighted different based both on your role and the emoji.
+
+### Use of Emojis in Discord for Experience Points Multiplier
+
+![](https://i.imgur.com/6o4PpVT.png)
+
+![](https://i.imgur.com/W3MNipm.jpg)

--- a/docs/playbooks/mgxp-metagame-experience-points.md
+++ b/docs/playbooks/mgxp-metagame-experience-points.md
@@ -4,7 +4,7 @@ description: 'This Playbook focuses on how XP works in MetaGame and how to earn 
 image: https://i.imgur.com/W3MNipm.jpg
 ---
 
-by @Maxwe11
+by [@Maxwe11](https://metagame.wtf/player/maxwe11)
 
 <details>
 <summary>🤔 Wait, WhoTF is @Maxwe11!?</summary>

--- a/docs/resources/glossary.md
+++ b/docs/resources/glossary.md
@@ -134,7 +134,7 @@ See [Guilds of MetaGame](https://my.metagame.wtf/guilds)
 
 Patrons are people who are too busy to support MetaGame by building it. Instead, they are buying, planting & holding Seeds that Players produce.
 
-See [more here]([https://www.notion.so/Patron-Path-1db90c8bb4c84398a6fe1f672ea5e855](https://metagame.wtf/join/patron))
+See [more here](https://metagame.wtf/join/patron)
 
 ## MetaFam
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,6 +56,7 @@ module.exports = {
       "playbooks/how-to-git-on-github-non-builder",
       "playbooks/how-to-build-a-network-for-impact",
       "playbooks/handling-fomo-in-web3",
+      "playbooks/mgxp-metagame-experience-points",
     ],
   },
 };


### PR DESCRIPTION
Adding the XP playbook (with corrections and feedback incorporated from #feedback-box) and updating the sidebar to include it in the navigation in metagame-wiki.