### PR TITLE
content update/house of ethereum/layer 2

### DIFF
--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -138,8 +138,8 @@ There are a bunch of wallets to choose from. **Your decision will mainly depend 
 Layer 2 is a collective term for solutions designed to help scale your application by handling transactions off the main Ethereum chain (layer 1). 
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
-- Check out the [House of L2s](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask and get some gas](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. Such as [our liquidity pool.](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Check out the [House of L2s and Sidechains](https://wiki.metagame.wtf/great-houses/house-of-L2s)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. Such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -139,8 +139,7 @@ Layer 2 is a collective term for solutions designed to help scale your applicati
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
 - Check out the [House of L2s and Sidechains](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. 
-- Such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon, like [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -138,8 +138,8 @@ There are a bunch of wallets to choose from. **Your decision will mainly depend 
 Layer 2 is a collective term for solutions designed to help scale your application by handling transactions off the main Ethereum chain (layer 1). 
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
-- Check out the [House of L2s] (https://github.com/MetaFam/metagame-wiki/docs/great-houses/house-of-L2s.md)
-- Follow this Playbook to [configure Polygon for MetaMask](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) and interact with dApps on Polygon. Such as [our liquidity pool] (https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Check out the [House of L2s](https://github.com/MetaFam/metagame-wiki/docs/great-houses/house-of-L2s.md)
+- Follow this Playbook to [configure Polygon for MetaMask](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) and interact with dApps on Polygon. Such as [our liquidity pool](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -132,17 +132,14 @@ There are a bunch of wallets to choose from. **Your decision will mainly depend 
 - Note: Whichever way you choose, you’ll likely need to store what we call a seed phrase. This is the most important bit. There are [many](https://www.google.com/search?client=firefox-b-d&q=storing+your+seed+phrase) [ways to do it](https://blog.trezor.io/https-blog-trezor-io-keep-your-seed-phrase-away-from-lions-edcc105457a0).
 - **NOTE: TAKE IT REALLY SERIOUSLY. STORE YOUR SEED PHRASE PHYSICALLY, NEVER COPY, PASTE OR ENTER IT ANYWHERE NEW
 
-## Layer 2 How-To
+
+## Layer 2 What
 
 Layer 2 is a collective term for solutions designed to help scale your application by handling transactions off the main Ethereum chain (layer 1). 
 
-- Understand [why layer 2 scaling is needed](https://ethereum.org/en/developers/docs/layer-2-scaling/) and learn about the different types of Layer 2 solutions.
-- Read more about the [State of Layer 2s](https://defiprime.com/ethereum-l2) as they are currently.
-- Instructions to [set up xDAI for MetaMask](https://xdaichain.com/for-users/wallets/metamask/metamask-setup) so that you can interact with the xDAI Layer.
-- How to [use the xDAI bridge](https://xdaichain.com/for-users/bridges/converting-xdai-via-bridge/moving-dai-to-xdai) to transfer assets from / to Ethereum mainnet.
-- Get a bit of xDAI to get you started at the [xDAI faucet](https://t.co/SXjJ0B7wRB?amp=1).
-- How to [configure Matic (Polygon) for MetaMask](https://docs.matic.network/docs/develop/metamask/config-matic/) to interact with dApps on Matic (Polygon).
-
+- What is [layer 2?](https://ethereum.org/en/layer-2/)  
+- Check out the [House of L2s] (https://github.com/MetaFam/metagame-wiki/docs/great-houses/house-of-L2s.md)
+- Follow this Playbook to [configure Polygon for MetaMask](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) and interact with dApps on Polygon. Such as [our liquidity pool] (https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -139,8 +139,8 @@ Layer 2 is a collective term for solutions designed to help scale your applicati
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
 - Check out the [House of L2s and Sidechains](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon, 
-such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) 
+- Explore and interact with dApps on Polygon, such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -139,7 +139,8 @@ Layer 2 is a collective term for solutions designed to help scale your applicati
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
 - Check out the [House of L2s and Sidechains](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon, like [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon, 
+such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -138,7 +138,7 @@ There are a bunch of wallets to choose from. **Your decision will mainly depend 
 Layer 2 is a collective term for solutions designed to help scale your application by handling transactions off the main Ethereum chain (layer 1). 
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
-- Check out the [House of L2s](https://github.com/MetaFam/metagame-wiki/docs/great-houses/house-of-L2s.md)
+- Check out the [House of L2s](https://wiki.metagame.wtf/great-houses/house-of-L2s)
 - Follow this Playbook to [configure Polygon for MetaMask](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) and interact with dApps on Polygon. Such as [our liquidity pool](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -139,7 +139,7 @@ Layer 2 is a collective term for solutions designed to help scale your applicati
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
 - Check out the [House of L2s](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) and interact with dApps on Polygon. Such as [our liquidity pool](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. Such as [our liquidity pool.](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -139,7 +139,8 @@ Layer 2 is a collective term for solutions designed to help scale your applicati
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
 - Check out the [House of L2s and Sidechains](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. Such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. 
+- Such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 

--- a/docs/great-houses/house-of-ethereum.md
+++ b/docs/great-houses/house-of-ethereum.md
@@ -139,7 +139,7 @@ Layer 2 is a collective term for solutions designed to help scale your applicati
 
 - What is [layer 2?](https://ethereum.org/en/layer-2/)  
 - Check out the [House of L2s and Sidechains](https://wiki.metagame.wtf/great-houses/house-of-L2s)
-- Follow this Playbook to [configure Polygon for MetaMask and get some gas](metagame-wiki/docs/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. Such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
+- Follow this Playbook to [configure Polygon for MetaMask and get some gas](https://wiki.metagame.wtf/playbooks/how-to-install-wallet-get-gas.md) then explore and interact with dApps on Polygon. Such as [our liquidity pool. 🌱](https://app.balancer.fi/#/polygon/pool/0x8a8fcd351ed553fc75aecbc566a32f94471f302e000100000000000000000081)
 
 
 


### PR DESCRIPTION

Updated the section on Layer 2 to lead to our House of Layer 2 link and the new playbook on setting up a wallet and getting gas.  Some of the old links were invalid.  And the information was dated.  I for now deleted the section on xDai rather than updating it to Gnosis, mainly to keep it focused at the moment on Polygon and to hyperlink back to resources we currently have created.
